### PR TITLE
Make reconciler leadership aware

### DIFF
--- a/pkg/interfaces/interfaces.go
+++ b/pkg/interfaces/interfaces.go
@@ -36,7 +36,12 @@ type StacksBackend interface {
 type SwarmResourceBackend interface {
 	network.ClusterBackend
 
+	// Info isn't actually in the swarm.Backend interface, but it is defined on
+	// the Cluster object, which provides the rest of the implementation
+	Info() swarm.Info
+
 	// The following methods are part of the swarm.Backend interface
+	GetNode(id string) (swarm.Node, error)
 	GetServices(dockerTypes.ServiceListOptions) ([]swarm.Service, error)
 	GetService(idOrName string, insertDefaults bool) (swarm.Service, error)
 	CreateService(swarm.ServiceSpec, string, bool) (*dockerTypes.ServiceCreateResponse, error)

--- a/pkg/interfaces/swarm_resource_shim.go
+++ b/pkg/interfaces/swarm_resource_shim.go
@@ -25,6 +25,24 @@ func NewSwarmAPIClientShim(dclient client.CommonAPIClient) SwarmResourceBackend 
 	}
 }
 
+// Info returns the swarm info
+func (c *SwarmResourceAPIClientShim) Info() swarm.Info {
+	// calls to Info return an error, but there's nothing we can do about that.
+	// because Backend call doesn't. So just return the empty Info object even
+	// if we get an error.
+	info, _ := c.dclient.Info(context.Background())
+	return info.Swarm
+}
+
+// GetNode returns a specific node by ID.
+func (c *SwarmResourceAPIClientShim) GetNode(id string) (swarm.Node, error) {
+	node, _, err := c.dclient.NodeInspectWithRaw(context.Background(), id)
+	if client.IsErrNotFound(err) {
+		return node, errdefs.NotFound(err)
+	}
+	return node, err
+}
+
 // GetServices lists services.
 func (c *SwarmResourceAPIClientShim) GetServices(options dockerTypes.ServiceListOptions) ([]swarm.Service, error) {
 	return c.dclient.ServiceList(context.Background(), options)

--- a/pkg/mocks/mock_backend.go
+++ b/pkg/mocks/mock_backend.go
@@ -203,6 +203,21 @@ func (mr *MockBackendClientMockRecorder) GetNetworksByName(arg0 interface{}) *go
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetNetworksByName", reflect.TypeOf((*MockBackendClient)(nil).GetNetworksByName), arg0)
 }
 
+// GetNode mocks base method
+func (m *MockBackendClient) GetNode(arg0 string) (swarm.Node, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetNode", arg0)
+	ret0, _ := ret[0].(swarm.Node)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// GetNode indicates an expected call of GetNode
+func (mr *MockBackendClientMockRecorder) GetNode(arg0 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetNode", reflect.TypeOf((*MockBackendClient)(nil).GetNode), arg0)
+}
+
 // GetSecret mocks base method
 func (m *MockBackendClient) GetSecret(arg0 string) (swarm.Secret, error) {
 	m.ctrl.T.Helper()
@@ -323,6 +338,20 @@ func (mr *MockBackendClientMockRecorder) GetTasks(arg0 interface{}) *gomock.Call
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetTasks", reflect.TypeOf((*MockBackendClient)(nil).GetTasks), arg0)
 }
 
+// Info mocks base method
+func (m *MockBackendClient) Info() swarm.Info {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "Info")
+	ret0, _ := ret[0].(swarm.Info)
+	return ret0
+}
+
+// Info indicates an expected call of Info
+func (mr *MockBackendClientMockRecorder) Info() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Info", reflect.TypeOf((*MockBackendClient)(nil).Info))
+}
+
 // ListStacks mocks base method
 func (m *MockBackendClient) ListStacks() ([]types0.Stack, error) {
 	m.ctrl.T.Helper()
@@ -351,6 +380,21 @@ func (m *MockBackendClient) ListSwarmStacks() ([]interfaces.SwarmStack, error) {
 func (mr *MockBackendClientMockRecorder) ListSwarmStacks() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListSwarmStacks", reflect.TypeOf((*MockBackendClient)(nil).ListSwarmStacks))
+}
+
+// ParseComposeInput mocks base method
+func (m *MockBackendClient) ParseComposeInput(arg0 types0.ComposeInput) (*types0.StackCreate, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "ParseComposeInput", arg0)
+	ret0, _ := ret[0].(*types0.StackCreate)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// ParseComposeInput indicates an expected call of ParseComposeInput
+func (mr *MockBackendClientMockRecorder) ParseComposeInput(arg0 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ParseComposeInput", reflect.TypeOf((*MockBackendClient)(nil).ParseComposeInput), arg0)
 }
 
 // RemoveConfig mocks base method
@@ -480,15 +524,15 @@ func (mr *MockBackendClientMockRecorder) UpdateService(arg0, arg1, arg2, arg3, a
 }
 
 // UpdateStack mocks base method
-func (m *MockBackendClient) UpdateStack(arg0 string, arg1 types0.StackSpec) error {
+func (m *MockBackendClient) UpdateStack(arg0 string, arg1 types0.StackSpec, arg2 uint64) error {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "UpdateStack", arg0, arg1)
+	ret := m.ctrl.Call(m, "UpdateStack", arg0, arg1, arg2)
 	ret0, _ := ret[0].(error)
 	return ret0
 }
 
 // UpdateStack indicates an expected call of UpdateStack
-func (mr *MockBackendClientMockRecorder) UpdateStack(arg0, arg1 interface{}) *gomock.Call {
+func (mr *MockBackendClientMockRecorder) UpdateStack(arg0, arg1, arg2 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UpdateStack", reflect.TypeOf((*MockBackendClient)(nil).UpdateStack), arg0, arg1)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UpdateStack", reflect.TypeOf((*MockBackendClient)(nil).UpdateStack), arg0, arg1, arg2)
 }

--- a/pkg/reconciler/manager_suite_test.go
+++ b/pkg/reconciler/manager_suite_test.go
@@ -1,0 +1,13 @@
+package reconciler
+
+import (
+	"testing"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+)
+
+func TestManager(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "Manager Suite")
+}

--- a/pkg/reconciler/manager_test.go
+++ b/pkg/reconciler/manager_test.go
@@ -1,0 +1,87 @@
+package reconciler
+
+import (
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+
+	"github.com/docker/docker/api/types/swarm"
+	"github.com/golang/mock/gomock"
+	"github.com/pkg/errors"
+
+	// strictly speaking, we don't have to use errdefs here -- no error
+	// checking actually occurs. However, to future-proof the tests, in case
+	// something happens later, we should return errdefs errors
+	"github.com/docker/docker/errdefs"
+
+	"github.com/docker/stacks/pkg/mocks"
+)
+
+var _ = Describe("reconciler.Manager", func() {
+	var (
+		m *Manager
+
+		ctrl       *gomock.Controller
+		mockClient *mocks.MockBackendClient
+	)
+
+	BeforeEach(func() {
+		ctrl = gomock.NewController(GinkgoT())
+		mockClient = mocks.NewMockBackendClient(ctrl)
+
+		m = New(mockClient)
+	})
+
+	AfterEach(func() {
+		ctrl.Finish()
+	})
+
+	Describe("checkLeadership", func() {
+		It("should return false if there is no node ID set", func() {
+			mockClient.EXPECT().GetNode("").Return(
+				swarm.Node{},
+				errdefs.NotFound(errors.New("not found")),
+			)
+
+			Expect(m.checkLeadership()).To(BeFalse())
+		})
+
+		When("the nodeID field is set", func() {
+			BeforeEach(func() {
+				m.nodeID = "foo"
+			})
+
+			It("should return false if the node is not a manager", func() {
+				mockClient.EXPECT().GetNode("foo").Return(
+					// no ManagerStatus field, no error
+					swarm.Node{ID: "foo"}, nil,
+				)
+
+				Expect(m.checkLeadership()).To(BeFalse())
+			})
+
+			It("should return false if the node is not the leader", func() {
+				mockClient.EXPECT().GetNode("foo").Return(
+					swarm.Node{
+						ID: "foo", ManagerStatus: &swarm.ManagerStatus{
+							Leader: false,
+						},
+					}, nil,
+				)
+
+				Expect(m.checkLeadership()).To(BeFalse())
+			})
+
+			It("should return true if the node is the leader", func() {
+				mockClient.EXPECT().GetNode("foo").Return(
+					swarm.Node{
+						ID: "foo", ManagerStatus: &swarm.ManagerStatus{
+							Leader: true,
+						},
+					}, nil,
+				)
+
+				Expect(m.checkLeadership()).To(BeTrue())
+			})
+		})
+	})
+})


### PR DESCRIPTION
Makes the reconciler manager aware of whether or not the current node is a swarmkit cluster manager and leader.

**Please review carefully, as the new code largely does not have tests**