### PR TITLE
Place Stack `Metadata` under `Spec` and add Labels

### DIFF
--- a/pkg/client/fake/fake_client.go
+++ b/pkg/client/fake/fake_client.go
@@ -54,10 +54,7 @@ func (c *StackClient) StackCreate(_ context.Context, stack types.StackCreate, _ 
 	c.mu.Lock()
 	defer c.mu.Unlock()
 	newStack := types.Stack{
-		ID: fmt.Sprintf("%d", c.idx),
-		Metadata: types.Metadata{
-			Name: stack.Metadata.Name,
-		},
+		ID:   fmt.Sprintf("%d", c.idx),
 		Spec: stack.Spec,
 	}
 	c.idx++

--- a/pkg/client/fake/fake_client_test.go
+++ b/pkg/client/fake/fake_client_test.go
@@ -2,22 +2,25 @@ package fake
 
 import (
 	"context"
-	"reflect"
 	"testing"
 
 	"github.com/docker/docker/errdefs"
 	"github.com/stretchr/testify/require"
+	"gotest.tools/assert"
 
 	composeTypes "github.com/docker/stacks/pkg/compose/types"
 	"github.com/docker/stacks/pkg/types"
 )
 
 var stackCreate = types.StackCreate{
-	Metadata: types.Metadata{
-		Name: "teststack",
-	},
 	Orchestrator: types.OrchestratorSwarm,
 	Spec: types.StackSpec{
+		Metadata: types.Metadata{
+			Name: "teststack",
+			Labels: map[string]string{
+				"key": "value",
+			},
+		},
 		Services: []composeTypes.ServiceConfig{
 			{
 				Name:  "service1",
@@ -68,14 +71,12 @@ func TestFakeStackClientCRUD(t *testing.T) {
 	require.NoError(err)
 	require.Len(stacks, 1)
 	require.Equal(stacks[0].Spec, stackCreate.Spec)
-	require.Equal(stacks[0].Metadata.Name, stackCreate.Metadata.Name)
 	require.Equal(stacks[0].ID, resp.ID)
 
 	// Inspect
 	stack, err := c.StackInspect(ctx, resp.ID)
 	require.NoError(err)
 	require.Equal(stack.Spec, stackCreate.Spec)
-	require.Equal(stack.Metadata.Name, stackCreate.Metadata.Name)
 	require.Equal(stack.ID, resp.ID)
 
 	// Update
@@ -84,7 +85,7 @@ func TestFakeStackClientCRUD(t *testing.T) {
 	require.NoError(c.StackUpdate(ctx, resp.ID, stack.Version, stackSpec, types.StackUpdateOptions{}))
 	stack, err = c.StackInspect(ctx, resp.ID)
 	require.NoError(err)
-	require.True(reflect.DeepEqual(stackSpec, stack.Spec))
+	assert.DeepEqual(t, stackSpec, stack.Spec)
 
 	// Delete
 	err = c.StackDelete(ctx, resp.ID)

--- a/pkg/kube/conversions_test.go
+++ b/pkg/kube/conversions_test.go
@@ -23,6 +23,12 @@ var (
 	parallelism   uint64 = 3
 
 	testStackSpec = types.StackSpec{
+		Metadata: types.Metadata{
+			Name: "test-stack",
+			Labels: map[string]string{
+				"stackkey": "value",
+			},
+		},
 		Collection: "namespace1",
 		Services: []composetypes.ServiceConfig{
 			{
@@ -106,7 +112,7 @@ var (
 					External: true,
 				},
 				Labels: map[string]string{
-					"key": "value",
+					"secretkey": "value",
 				},
 			},
 		},
@@ -117,7 +123,7 @@ var (
 					External: true,
 				},
 				Labels: map[string]string{
-					"key": "value",
+					"configkey": "value",
 				},
 			},
 			"config2": {
@@ -221,7 +227,7 @@ var (
 					External: true,
 				},
 				Labels: map[string]string{
-					"key": "value",
+					"secretkey": "value",
 				},
 			},
 		},
@@ -232,7 +238,7 @@ var (
 					External: true,
 				},
 				Labels: map[string]string{
-					"key": "value",
+					"configkey": "value",
 				},
 			},
 			"config2": {
@@ -243,17 +249,17 @@ var (
 
 	testKubeStack = v1beta2.Stack{
 		ObjectMeta: metav1.ObjectMeta{
-			Name:            "test-stack",
-			Namespace:       "namespace1",
+			Name:      "test-stack",
+			Namespace: "namespace1",
+			Annotations: map[string]string{
+				"stackkey": "value",
+			},
 			ResourceVersion: "16",
 		},
 		Spec: &testKubeStackSpec,
 	}
 
 	testStack = types.Stack{
-		Metadata: types.Metadata{
-			Name: "test-stack",
-		},
 		ID:   "kube_namespace1_test-stack",
 		Spec: testStackSpec,
 		Version: types.Version{
@@ -265,7 +271,9 @@ var (
 
 func TestFromStackSpec(t *testing.T) {
 	resp := FromStackSpec(testStackSpec)
-	assert.DeepEqual(t, *resp, testKubeStackSpec)
+	// Hardcode the version as we are not actually aware of it just from the stack spec
+	resp.ObjectMeta.ResourceVersion = "16"
+	assert.DeepEqual(t, *resp, testKubeStack)
 }
 
 func TestConvertFromKubeStack(t *testing.T) {

--- a/pkg/kube/kube_test.go
+++ b/pkg/kube/kube_test.go
@@ -64,10 +64,10 @@ func TestKubeStacksBackendStackCreate(t *testing.T) {
 	k.EXPECT().Create(gomock.Any()).Return(nil, nil)
 
 	create := types.StackCreate{
-		Metadata: types.Metadata{
-			Name: "testname",
-		},
 		Spec: types.StackSpec{
+			Metadata: types.Metadata{
+				Name: "testname",
+			},
 			Collection: "namespace1",
 		},
 	}
@@ -93,6 +93,9 @@ func TestKubeStacksBackendStackInspect(t *testing.T) {
 			Name:            "testname",
 			Namespace:       "namespace1",
 			ResourceVersion: "42",
+			Annotations: map[string]string{
+				"key": "value",
+			},
 		},
 		Spec: &v1beta2.StackSpec{
 			Services: []v1beta2.ServiceConfig{
@@ -105,9 +108,10 @@ func TestKubeStacksBackendStackInspect(t *testing.T) {
 
 	stack, err := b.StackInspect(context.TODO(), "kube_namespace1_testname")
 	require.NoError(err)
-	require.Equal(stack.Metadata.Name, "testname")
 	require.Equal(stack.Version.Index, uint64(42))
 	require.Equal(stack.Spec.Collection, "namespace1")
+	require.Equal(stack.Spec.Metadata.Name, "testname")
+	require.Equal(stack.Spec.Metadata.Labels["key"], "value")
 	require.Len(stack.Spec.Services, 1)
 	require.Equal(stack.Spec.Services[0].Image, "service1")
 }
@@ -241,7 +245,7 @@ func TestKubeStacksBackendStackList(t *testing.T) {
 	}
 
 	for _, stack := range stacks {
-		require.Equal(stack.Metadata.Name, "testname")
+		require.Equal(stack.Spec.Metadata.Name, "testname")
 		targetImage, ok := found[stack.Spec.Collection]
 		require.True(ok)
 		require.Equal(stack.Spec.Services[0].Image, targetImage)

--- a/pkg/kube/tokube.go
+++ b/pkg/kube/tokube.go
@@ -6,6 +6,7 @@ import (
 	"strings"
 
 	"github.com/docker/compose-on-kubernetes/api/compose/v1beta2"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	composetypes "github.com/docker/stacks/pkg/compose/types"
 	"github.com/docker/stacks/pkg/types"
@@ -27,12 +28,23 @@ const (
 	swarmLabelPrefix = "node.labels."
 )
 
-// FromStackSpec converts a StackSpec to a v1beta2.StackSpec.
-func FromStackSpec(spec types.StackSpec) *v1beta2.StackSpec {
-	return &v1beta2.StackSpec{
-		Services: fromComposeServices(spec.Services),
-		Secrets:  fromComposeSecrets(spec.Secrets),
-		Configs:  fromComposeConfigs(spec.Configs),
+// FromStackSpec converts a StackSpec to a v1beta2.Stack
+func FromStackSpec(spec types.StackSpec) *v1beta2.Stack {
+	namespace := spec.Collection
+	if namespace == "" {
+		namespace = "default"
+	}
+	return &v1beta2.Stack{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:        spec.Metadata.Name,
+			Namespace:   namespace,
+			Annotations: spec.Metadata.Labels,
+		},
+		Spec: &v1beta2.StackSpec{
+			Services: fromComposeServices(spec.Services),
+			Secrets:  fromComposeSecrets(spec.Secrets),
+			Configs:  fromComposeConfigs(spec.Configs),
+		},
 	}
 }
 

--- a/pkg/store/marshal_test.go
+++ b/pkg/store/marshal_test.go
@@ -32,13 +32,16 @@ func TestMarshalUnmarshal(t *testing.T) {
 	// not JSON marshalling. just add some canned data
 	stack := &types.Stack{
 		ID: "someID",
-		Metadata: types.Metadata{
-			Name: "someName",
-		},
 		Version: types.Version{
 			Index: 1,
 		},
 		Spec: types.StackSpec{
+			Metadata: types.Metadata{
+				Name: "someName",
+				Labels: map[string]string{
+					"key": "value",
+				},
+			},
 			Services: composetypes.Services{
 				{
 					Name: "bar",
@@ -60,6 +63,9 @@ func TestMarshalUnmarshal(t *testing.T) {
 		Spec: interfaces.SwarmStackSpec{
 			Annotations: swarm.Annotations{
 				Name: "someName",
+				Labels: map[string]string{
+					"key": "value",
+				},
 			},
 			Services: []swarm.ServiceSpec{
 				{

--- a/pkg/store/store_functions.go
+++ b/pkg/store/store_functions.go
@@ -121,8 +121,12 @@ func UpdateStack(ctx context.Context, rc ResourcesClient, id string, st types.St
 		&swarmapi.UpdateResourceRequest{
 			ResourceID:      id,
 			ResourceVersion: &swarmapi.Version{Index: version},
-			// we don't need to set the value of Annotations. leaving it empty
-			// indicates no change
+			Annotations: &swarmapi.Annotations{
+				// Swarmkit will return an error if any changes to the
+				// name occur.
+				Name:   sst.Annotations.Name,
+				Labels: sst.Annotations.Labels,
+			},
 			Payload: any,
 		},
 	)

--- a/pkg/store/store_test.go
+++ b/pkg/store/store_test.go
@@ -58,10 +58,13 @@ var _ = Describe("StackStore", func() {
 
 			// these are essentially the same stacks from marshal_test.go
 			stack = &types.Stack{
-				Metadata: types.Metadata{
-					Name: "someName",
-				},
 				Spec: types.StackSpec{
+					Metadata: types.Metadata{
+						Name: "someName",
+						Labels: map[string]string{
+							"key": "value",
+						},
+					},
 					Services: composetypes.Services{
 						{
 							Name: "bar",
@@ -75,6 +78,9 @@ var _ = Describe("StackStore", func() {
 				Spec: interfaces.SwarmStackSpec{
 					Annotations: swarm.Annotations{
 						Name: "someName",
+						Labels: map[string]string{
+							"key": "value",
+						},
 					},
 					Services: []swarm.ServiceSpec{
 						{
@@ -97,7 +103,8 @@ var _ = Describe("StackStore", func() {
 			stackResource = &swarmapi.Resource{
 				ID: "someID",
 				Annotations: swarmapi.Annotations{
-					Name: "someName",
+					Name:   swarmStack.Spec.Annotations.Name,
+					Labels: swarmStack.Spec.Annotations.Labels,
 				},
 				Meta: swarmapi.Meta{
 					CreatedAt: timeProto,
@@ -114,11 +121,9 @@ var _ = Describe("StackStore", func() {
 			mockClient.EXPECT().CreateResource(
 				context.TODO(),
 				&swarmapi.CreateResourceRequest{
-					Annotations: &swarmapi.Annotations{
-						Name: "someName",
-					},
-					Kind:    StackResourceKind,
-					Payload: stackResource.Payload,
+					Annotations: &stackResource.Annotations,
+					Kind:        StackResourceKind,
+					Payload:     stackResource.Payload,
 				},
 			).Return(
 				&swarmapi.CreateResourceResponse{
@@ -153,10 +158,13 @@ var _ = Describe("StackStore", func() {
 				Version: types.Version{
 					Index: stackResource.Meta.Version.Index,
 				},
-				Metadata: types.Metadata{
-					Name: "someName",
-				},
 				Spec: types.StackSpec{
+					Metadata: types.Metadata{
+						Name: "someName",
+						Labels: map[string]string{
+							"key": "value",
+						},
+					},
 					Services: composetypes.Services{
 						{
 							// change bar -> baz
@@ -179,6 +187,9 @@ var _ = Describe("StackStore", func() {
 				Spec: interfaces.SwarmStackSpec{
 					Annotations: swarm.Annotations{
 						Name: "someName",
+						Labels: map[string]string{
+							"key": "value",
+						},
 					},
 					Services: []swarm.ServiceSpec{
 						{
@@ -211,6 +222,7 @@ var _ = Describe("StackStore", func() {
 				&swarmapi.UpdateResourceRequest{
 					ResourceID:      stackResource.ID,
 					ResourceVersion: &stackResource.Meta.Version,
+					Annotations:     &stackResource.Annotations,
 					Payload:         newAny,
 				},
 			).Return(
@@ -247,7 +259,6 @@ var _ = Describe("StackStore", func() {
 				Version: types.Version{
 					Index: stackResource.Meta.Version.Index,
 				},
-				Metadata:     stack.Metadata,
 				Orchestrator: stack.Orchestrator,
 				Spec:         stack.Spec,
 			}
@@ -307,10 +318,14 @@ var _ = Describe("StackStore", func() {
 			BeforeEach(func() {
 				for i := 0; i < numListedResources; i++ {
 					st := types.Stack{
-						Metadata: types.Metadata{
-							Name: fmt.Sprintf("stack_%v", i),
-						},
 						Spec: types.StackSpec{
+							Metadata: types.Metadata{
+								Name: fmt.Sprintf("stack_%v", i),
+
+								Labels: map[string]string{
+									"key": "value",
+								},
+							},
 							Services: composetypes.Services{
 								{
 									Name: fmt.Sprintf("svc_%v", i),
@@ -321,7 +336,8 @@ var _ = Describe("StackStore", func() {
 					sst := interfaces.SwarmStack{
 						Spec: interfaces.SwarmStackSpec{
 							Annotations: swarm.Annotations{
-								Name: st.Metadata.Name,
+								Name:   st.Spec.Metadata.Name,
+								Labels: st.Spec.Metadata.Labels,
 							},
 							Services: []swarm.ServiceSpec{
 								{
@@ -347,7 +363,8 @@ var _ = Describe("StackStore", func() {
 							UpdatedAt: timeProto,
 						},
 						Annotations: swarmapi.Annotations{
-							Name: st.Metadata.Name,
+							Name:   st.Spec.Metadata.Name,
+							Labels: st.Spec.Metadata.Labels,
 						},
 						Kind:    StackResourceKind,
 						Payload: any,

--- a/pkg/types/stack.go
+++ b/pkg/types/stack.go
@@ -7,7 +7,6 @@ import (
 
 // Stack represents a runtime instantiation of a Docker Compose based application
 type Stack struct {
-	Metadata
 	Version
 	Spec           StackSpec          `json:"spec"`
 	StackResources StackResources     `json:"stack_resources"`
@@ -40,14 +39,14 @@ type Version struct {
 
 // StackCreate is input to the Create operation for a Stack
 type StackCreate struct {
-	Metadata
 	Spec         StackSpec          `json:"spec"`
 	Orchestrator OrchestratorChoice `json:"orchestrator"`
 }
 
 // Metadata contains metadata for a Stack.
 type Metadata struct {
-	Name string
+	Name   string
+	Labels map[string]string
 }
 
 // StackList is the output for Stack listing
@@ -57,6 +56,7 @@ type StackList struct {
 
 // StackSpec defines the desired state of Stack
 type StackSpec struct {
+	Metadata
 	Services       types.Services                   `json:"services,omitempty"`
 	Secrets        map[string]types.SecretConfig    `json:"secrets,omitempty"`
 	Configs        map[string]types.ConfigObjConfig `json:"configs,omitempty"`


### PR DESCRIPTION
This PR re-wires the `Stack.Metadata` field to be under `Stack.Spec.Metadata`. It also adds a new "Labels" field to it, and ensures labels are properly converted to the underlying `SwarmStack.Annotations.Labels` and `KubeStack.ObjectMeta.Annotations` fields on both orchestrators.

cc @dperny for swarmkit store test changes

cc @dhiltgen for potential changes to the CLI

cc @simonferquel @chris-crone for the kubernetes side